### PR TITLE
Fix crash in the server installer on Windows

### DIFF
--- a/src/main/java/org/quiltmc/installer/action/InstallServer.java
+++ b/src/main/java/org/quiltmc/installer/action/InstallServer.java
@@ -255,7 +255,8 @@ public final class InstallServer extends Action<InstallServer.MessageType> {
 	private static CompletableFuture<Path> downloadLibrary(String name, String url) {
 		return CompletableFuture.supplyAsync(() -> {
 			try {
-				Path path = Files.createTempFile(name, null);
+				String shortName = name.split(":")[1];
+				Path path = Files.createTempFile(shortName, null);
 
 				// Convert to maven url
 				String rawUrl = mavenToUrl(url, name);

--- a/src/main/java/org/quiltmc/installer/action/InstallServer.java
+++ b/src/main/java/org/quiltmc/installer/action/InstallServer.java
@@ -255,7 +255,9 @@ public final class InstallServer extends Action<InstallServer.MessageType> {
 	private static CompletableFuture<Path> downloadLibrary(String name, String url) {
 		return CompletableFuture.supplyAsync(() -> {
 			try {
-				String shortName = name.split(":")[1];
+				// Windows does not accept semicolons in filenames, so, we remove them
+				String[] splitName = name.split(":");
+				String shortName = splitName[1] + splitName[2];
 				Path path = Files.createTempFile(shortName, null);
 
 				// Convert to maven url


### PR DESCRIPTION
Previously, if you attempted to install a Quilt server with the installer on Windows, it would say that it finished installing it in the GUI despite doing nothing and the CLI would show a more helpful error saying that a semicolon is an illegal character for the temporary library files. This PR fixes that by ~~only using the artifact ID~~ joining together the artifact ID and version and use it for the temporary file name