### PR TITLE
Use installDir for installing the client, fix #3

### DIFF
--- a/src/main/java/org/quiltmc/installer/action/Action.java
+++ b/src/main/java/org/quiltmc/installer/action/Action.java
@@ -88,9 +88,8 @@ public abstract class Action<M> {
 		return new ListVersions(snapshots);
 	}
 
-	// TODO: Use install dir
 	public static InstallClient installClient(String minecraftVersion, @Nullable String loaderVersion, @Nullable String installDir, boolean generateProfile) {
-		return new InstallClient(minecraftVersion, loaderVersion, generateProfile);
+		return new InstallClient(minecraftVersion, loaderVersion, installDir, generateProfile);
 	}
 
 	public static InstallServer installServer(String minecraftVersion, @Nullable String loaderVersion, String installDir, boolean createScripts, boolean installServer) {

--- a/src/main/java/org/quiltmc/installer/gui/swing/ClientPanel.java
+++ b/src/main/java/org/quiltmc/installer/gui/swing/ClientPanel.java
@@ -139,6 +139,8 @@ final class ClientPanel extends AbstractPanel implements Consumer<InstallClient.
 		);
 
 		action.run(this);
+
+		showInstalledMessage();
 	}
 
 	@Override


### PR DESCRIPTION
Code from InstallServer and ServerPanel has been borrowed in order to use installDir in the client installation and show the dialog once it installs successfully