### PR TITLE
grab JRE from minecraft folder on Mac

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -3,10 +3,39 @@
 version = 3
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "block"
@@ -58,6 +87,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +134,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
+name = "dirs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+dependencies = [
+ "libc",
+ "redox_users 0.3.5",
+ "winapi",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,7 +171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.0",
  "winapi",
 ]
 
@@ -147,14 +203,31 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -254,6 +327,7 @@ dependencies = [
 name = "quilt-installer"
 version = "0.1.0"
 dependencies = [
+ "dirs",
  "embed-resource",
  "native-dialog",
  "open",
@@ -299,7 +373,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -322,6 +396,12 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_syscall"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
@@ -331,12 +411,35 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+dependencies = [
+ "getrandom 0.1.16",
+ "redox_syscall 0.1.57",
+ "rust-argon2",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom",
- "redox_syscall",
+ "getrandom 0.2.2",
+ "redox_syscall 0.2.5",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
+dependencies = [
+ "base64",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -410,6 +513,12 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -18,6 +18,9 @@ rand = { version = "0.8.3" }
 # Error dialogs
 native-dialog = { version = "0.5.5" }
 
+# Get the home directory on Mac (might be a better way?)
+dirs = { version = "1.0.4" }
+
 [target.'cfg(windows)'.dependencies]
 # Lookup in registry for installation location for additional JREs
 winreg = { version = "0.8.0" }

--- a/native/src/macos.rs
+++ b/native/src/macos.rs
@@ -1,14 +1,16 @@
 //! macOS dependent logic
 
 use std::io;
+use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
+use dirs::home_dir;
 
 // Warning: Untested
 
 pub const PLATFORM_JAVA_EXECUTABLE_NAME: &str = "java";
 pub const INSTALLER_JRE_HELP_URL: &str = "https://quiltmc.org"; // TODO: Fill in URL
 
-pub(crate) fn get_jre_locations() -> io::Result<Vec<PathBuf>> {
+pub(crate) fn get_host_jre_locations() -> io::Result<Vec<PathBuf>> {
 	// macOS will store all the jvms inside of `/Library/Java/JavaVirtualMachines/`
 	let jvms = PathBuf::from("/Library/Java/JavaVirtualMachines/");
 	let child_dirs = jvms.read_dir()?;
@@ -27,4 +29,54 @@ pub(crate) fn get_jre_locations() -> io::Result<Vec<PathBuf>> {
 	// TODO: Does the launcher bundle it's own jvms or store those somewhere?
 
 	Ok(jvms)
+}
+
+fn launcher_install_dir() -> io::Result<PathBuf> {
+	println!("Attempting to find Minecraft folder in Application Support");
+
+	let home = home_dir();
+
+	if let Some(home) = home {
+		let extended: PathBuf = ["Library", "Application Support", "minecraft"].iter().collect();
+
+		let path = home.join(extended);
+
+		if path.exists() {
+			Ok(path)
+		} else {
+			Err(Error::new(ErrorKind::Other, "Can't find Minecraft location! That is VERY BAD! How did I do that?"))
+		}
+	} else {
+		Err(Error::new(ErrorKind::Other, "Can't find Minecraft location! This must be running without a home dir!"))
+	}
+}
+
+pub(crate) fn get_jre_locations() -> io::Result<Vec<PathBuf>> {
+	let paths = vec![
+		//oh lord I hope these are correct
+		"runtime/jre-x64/jre.bundle/Contents/Home/bin/java",
+		"runtime/jre-legacy/jre.bundle/Contents/Home/bin/java",
+		"runtime/java-runtime-alpha/macos/java-runtime-alpha/jre.bundle/Contents/Home/bin/java",
+		"runtime/java-runtime-beta/macos/java-runtime-beta/jre.bundle/Contents/Home/bin/java",
+	];
+
+	let mut candidates = Vec::new();
+
+	let installer_dir = launcher_install_dir();
+
+	if let Ok(installer_dir) = installer_dir {
+		for x in &paths {
+			candidates.push(installer_dir.join(x));
+		}
+	}
+
+	let host_jvms = get_host_jre_locations();
+
+	if let Ok(host_jvms) = host_jvms {
+		for host_jvm in host_jvms {
+			candidates.push(host_jvm);
+		}
+	}
+
+	Ok(candidates)
 }


### PR DESCRIPTION
Will attempt to grab the Minecraft launcher's included JRE from `~/Library/Application Support/minecraft`. Checks for `runtime/jre-x64/jre.bundle/Contents/Home/bin/java`, `runtime/jre-legacy/jre.bundle/Contents/Home/bin/java`, `runtime/java-runtime-alpha/macos/java-runtime-alpha/jre.bundle/Contents/Home/bin/java`, and `runtime/java-runtime-beta/macos/java-runtime-beta/jre.bundle/Contents/Home/bin/java`. Tested (lightly) and working!