### PR TITLE
Fix java-runtime-gamma not being detected

### DIFF
--- a/native/src/macos.rs
+++ b/native/src/macos.rs
@@ -58,6 +58,8 @@ pub(crate) fn get_jre_locations() -> io::Result<Vec<PathBuf>> {
 		"runtime/jre-legacy/jre.bundle/Contents/Home/bin/java",
 		"runtime/java-runtime-alpha/macos/java-runtime-alpha/jre.bundle/Contents/Home/bin/java",
 		"runtime/java-runtime-beta/macos/java-runtime-beta/jre.bundle/Contents/Home/bin/java",
+		"runtime/java-runtime-gamma/macos/java-runtime-gamma/jre.bundle/Contents/Home/bin/java",
+		"runtime/java-runtime-delta/macos/java-runtime-delta/jre.bundle/Contents/Home/bin/java",
 	];
 
 	let mut candidates = Vec::new();

--- a/native/src/windows.rs
+++ b/native/src/windows.rs
@@ -54,9 +54,11 @@ pub(crate) fn get_jre_locations() -> io::Result<Vec<PathBuf>> {
 		"runtime/java-runtime-alpha/windows-x86/javaw.exe",
 		"runtime/java-runtime-beta/windows-x86/javaw.exe",
 		"runtime/java-runtime-beta/windows-x64/javaw.exe",
-		// Haven't seen these in the wild, but it's worth future-proofing I guess
-		"runtime/java-runtime/windows-x64/javaw.exe",
-		"runtime/java-runtime/windows-x86/javaw.exe"
+		"runtime/java-runtime-gamma/windows-x86/javaw.exe",
+		"runtime/java-runtime-gamma/windows-x64/javaw.exe",
+		// All signs point to a versioning scheme based on Greek letters. Let's future-proof it against the next predicted one 
+		"runtime/java-runtime-delta/windows-x64/javaw.exe",
+		"runtime/java-runtime-delta/windows-x86/javaw.exe"
 	];
 
 	let mut candidates = Vec::new();


### PR DESCRIPTION
This also future-proofs against the possible next runtime version: java-runtime-delta