### PR TITLE
Add User-Agent header

### DIFF
--- a/src/main/java/org/quiltmc/installer/Connections.java
+++ b/src/main/java/org/quiltmc/installer/Connections.java
@@ -1,0 +1,25 @@
+package org.quiltmc.installer;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+
+public class Connections {
+    public static final String INSTALLER_VERSION = getInstallerVersion();
+
+    private static String getInstallerVersion() {
+        String version = QuiltMeta.class.getPackage().getImplementationVersion();
+        if (version != null) {
+            return version;
+        }
+
+        return "dev";
+    }
+
+    public static URLConnection openConnection(URL url) throws IOException {
+        URLConnection connection = url.openConnection();
+        connection.setRequestProperty("User-Agent", "Quilt-Installer/"+INSTALLER_VERSION);
+
+        return connection;
+    }
+}

--- a/src/main/java/org/quiltmc/installer/Connections.java
+++ b/src/main/java/org/quiltmc/installer/Connections.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.installer;
 
 import java.io.IOException;

--- a/src/main/java/org/quiltmc/installer/LaunchJson.java
+++ b/src/main/java/org/quiltmc/installer/LaunchJson.java
@@ -41,7 +41,7 @@ public final class LaunchJson {
 		return CompletableFuture.supplyAsync(() -> {
 			try {
 				URL url = new URL(rawUrl);
-				URLConnection connection = url.openConnection();
+				URLConnection connection = QuiltMeta.openMetaConnection(url);
 
 				InputStreamReader stream = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8);
 

--- a/src/main/java/org/quiltmc/installer/LaunchJson.java
+++ b/src/main/java/org/quiltmc/installer/LaunchJson.java
@@ -41,7 +41,7 @@ public final class LaunchJson {
 		return CompletableFuture.supplyAsync(() -> {
 			try {
 				URL url = new URL(rawUrl);
-				URLConnection connection = QuiltMeta.openMetaConnection(url);
+				URLConnection connection = Connections.openConnection(url);
 
 				InputStreamReader stream = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8);
 

--- a/src/main/java/org/quiltmc/installer/QuiltMeta.java
+++ b/src/main/java/org/quiltmc/installer/QuiltMeta.java
@@ -16,7 +16,10 @@
 
 package org.quiltmc.installer;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
@@ -103,7 +106,6 @@ public final class QuiltMeta {
 	public static final String DEFAULT_FABRIC_META_URL = "https://meta.fabricmc.net";
 	private final Map<Endpoint<?>, Object> endpoints;
 
-
 	public static CompletableFuture<QuiltMeta> create(String baseQuiltMetaUrl, String baseFabricMetaUrl, Set<Endpoint<?>> endpoints) {
 		Map<Endpoint<?>, CompletableFuture<?>> futures = new HashMap<>();
 		for (Endpoint<?> endpoint : endpoints) {
@@ -140,15 +142,6 @@ public final class QuiltMeta {
 
 			return new QuiltMeta(baseQuiltMetaUrl, resolvedEndpoints);
 		});
-	}
-
-	private static String getInstallerVersion() {
-		String version = QuiltMeta.class.getPackage().getImplementationVersion();
-		if (version != null) {
-			return version;
-		}
-
-		return "dev";
 	}
 
 	private static Endpoint<List<String>> createVersion(String endpointPath) {

--- a/src/main/java/org/quiltmc/installer/QuiltMeta.java
+++ b/src/main/java/org/quiltmc/installer/QuiltMeta.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.jar.Manifest;
 
 import org.quiltmc.json5.JsonReader;
 import org.quiltmc.json5.JsonToken;
@@ -102,15 +101,8 @@ public final class QuiltMeta {
 
 	public static final String DEFAULT_META_URL = "https://meta.quiltmc.org";
 	public static final String DEFAULT_FABRIC_META_URL = "https://meta.fabricmc.net";
-	private static final String INSTALLER_VERSION = getInstallerVersion();
 	private final Map<Endpoint<?>, Object> endpoints;
 
-	public static URLConnection openMetaConnection(URL url) throws IOException {
-		URLConnection connection = url.openConnection();
-		connection.setRequestProperty("User-Agent", "Quilt-Installer/"+INSTALLER_VERSION);
-
-		return connection;
-	}
 
 	public static CompletableFuture<QuiltMeta> create(String baseQuiltMetaUrl, String baseFabricMetaUrl, Set<Endpoint<?>> endpoints) {
 		Map<Endpoint<?>, CompletableFuture<?>> futures = new HashMap<>();
@@ -124,7 +116,7 @@ public final class QuiltMeta {
 						url = new URL(baseQuiltMetaUrl + endpoint.endpointPath);
 					}
 
-					URLConnection connection = openMetaConnection(url);
+					URLConnection connection = Connections.openConnection(url);
 
 					InputStreamReader stream = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8);
 

--- a/src/main/java/org/quiltmc/installer/QuiltMeta.java
+++ b/src/main/java/org/quiltmc/installer/QuiltMeta.java
@@ -105,6 +105,13 @@ public final class QuiltMeta {
 	private static final String INSTALLER_VERSION = getInstallerVersion();
 	private final Map<Endpoint<?>, Object> endpoints;
 
+	public static URLConnection openMetaConnection(URL url) throws IOException {
+		URLConnection connection = url.openConnection();
+		connection.setRequestProperty("User-Agent", "Quilt-Installer/"+INSTALLER_VERSION);
+
+		return connection;
+	}
+
 	public static CompletableFuture<QuiltMeta> create(String baseQuiltMetaUrl, String baseFabricMetaUrl, Set<Endpoint<?>> endpoints) {
 		Map<Endpoint<?>, CompletableFuture<?>> futures = new HashMap<>();
 		for (Endpoint<?> endpoint : endpoints) {
@@ -117,8 +124,7 @@ public final class QuiltMeta {
 						url = new URL(baseQuiltMetaUrl + endpoint.endpointPath);
 					}
 
-					URLConnection connection = url.openConnection();
-					connection.setRequestProperty("User-Agent", "Quilt-Installer/"+INSTALLER_VERSION);
+					URLConnection connection = openMetaConnection(url);
 
 					InputStreamReader stream = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8);
 

--- a/src/main/java/org/quiltmc/installer/QuiltMeta.java
+++ b/src/main/java/org/quiltmc/installer/QuiltMeta.java
@@ -16,10 +16,7 @@
 
 package org.quiltmc.installer;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.UncheckedIOException;
+import java.io.*;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
@@ -31,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.jar.Manifest;
 
 import org.quiltmc.json5.JsonReader;
 import org.quiltmc.json5.JsonToken;
@@ -104,6 +102,7 @@ public final class QuiltMeta {
 
 	public static final String DEFAULT_META_URL = "https://meta.quiltmc.org";
 	public static final String DEFAULT_FABRIC_META_URL = "https://meta.fabricmc.net";
+	private static final String INSTALLER_VERSION = getInstallerVersion();
 	private final Map<Endpoint<?>, Object> endpoints;
 
 	public static CompletableFuture<QuiltMeta> create(String baseQuiltMetaUrl, String baseFabricMetaUrl, Set<Endpoint<?>> endpoints) {
@@ -119,6 +118,7 @@ public final class QuiltMeta {
 					}
 
 					URLConnection connection = url.openConnection();
+					connection.setRequestProperty("User-Agent", "Quilt-Installer/"+INSTALLER_VERSION);
 
 					InputStreamReader stream = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8);
 
@@ -142,6 +142,15 @@ public final class QuiltMeta {
 
 			return new QuiltMeta(baseQuiltMetaUrl, resolvedEndpoints);
 		});
+	}
+
+	private static String getInstallerVersion() {
+		String version = QuiltMeta.class.getPackage().getImplementationVersion();
+		if (version != null) {
+			return version;
+		}
+
+		return "dev";
 	}
 
 	private static Endpoint<List<String>> createVersion(String endpointPath) {

--- a/src/main/java/org/quiltmc/installer/VersionManifest.java
+++ b/src/main/java/org/quiltmc/installer/VersionManifest.java
@@ -24,13 +24,11 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.quiltmc.json5.JsonReader;
 import org.quiltmc.json5.JsonToken;
@@ -49,7 +47,7 @@ public final class VersionManifest implements Iterable<VersionManifest.Version> 
 		return CompletableFuture.supplyAsync(() -> {
 			try {
 				URL url = new URL(LAUNCHER_META_URL);
-				URLConnection connection = url.openConnection();
+				URLConnection connection = Connections.openConnection(url);
 
 				InputStreamReader stream = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8);
 

--- a/src/main/java/org/quiltmc/installer/action/InstallServer.java
+++ b/src/main/java/org/quiltmc/installer/action/InstallServer.java
@@ -33,9 +33,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -45,14 +43,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.jar.Attributes;
-import java.util.jar.JarEntry;
-import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import org.jetbrains.annotations.Nullable;
+import org.quiltmc.installer.Connections;
 import org.quiltmc.installer.Gsons;
 import org.quiltmc.installer.LaunchJson;
 import org.quiltmc.installer.VersionManifest;
@@ -200,7 +197,7 @@ public final class InstallServer extends Action<InstallServer.MessageType> {
 
 			try {
 				URL url = new URL(rawUrl);
-				URLConnection connection = url.openConnection();
+				URLConnection connection = Connections.openConnection(url);
 
 				InputStreamReader stream = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8);
 
@@ -242,7 +239,7 @@ public final class InstallServer extends Action<InstallServer.MessageType> {
 
 						println(String.format("Downloading %s server jar from %s", minecraftVersion, rawServerUrl.toString()));
 
-						try (InputStream serverDownloadStream = new URL(rawServerUrl.toString()).openConnection().getInputStream()) {
+						try (InputStream serverDownloadStream = Connections.openConnection(new URL(rawServerUrl.toString())).getInputStream()) {
 							Files.copy(serverDownloadStream, installDir.resolve("server.jar"), StandardCopyOption.REPLACE_EXISTING);
 						}
 					}
@@ -263,7 +260,7 @@ public final class InstallServer extends Action<InstallServer.MessageType> {
 				String rawUrl = mavenToUrl(url, name);
 				println("Downloading library at: " + rawUrl);
 
-				URLConnection connection = new URL(rawUrl).openConnection();
+				URLConnection connection = Connections.openConnection(new URL(rawUrl));
 
 				try (InputStream stream = connection.getInputStream()) {
 					Files.createDirectories(path.getParent());


### PR DESCRIPTION
This should add a user-agent header to every request that it makes. I have tested this with wireshark and the compiled installer jar, and the requests that I inspected included a `User-Agent: Quilt-Installer/0.5.0` header, as desired. Let me know if there's changes you'd like.