### PR TITLE
Remove duplicate libraries

### DIFF
--- a/src/main/java/org/quiltmc/installer/LaunchJson.java
+++ b/src/main/java/org/quiltmc/installer/LaunchJson.java
@@ -30,6 +30,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.concurrent.CompletableFuture;
 
 public final class LaunchJson {
@@ -78,13 +80,20 @@ public final class LaunchJson {
 			}
 
 			// TODO: HACK HACK HACK: inject intermediary instead of hashed
+			Set<String> libraryNames = new HashSet<>();
+			List<Map<String, String>> newLibraries = new ArrayList<>();
 			@SuppressWarnings("unchecked") List<Map<String, String>> libraries = (List<Map<String, String>>) map.get("libraries");
 			for (Map<String, String> library : libraries) {
 				if (library.get("name").startsWith("org.quiltmc:hashed")) {
 					library.replace("name", library.get("name").replace("org.quiltmc:hashed", "net.fabricmc:intermediary"));
 					library.replace("url", "https://maven.fabricmc.net/");
 				}
+				if (!libraryNames.contains(library.get("name"))) {
+        				libraryNames.add(library.get("name"));
+        				newLibraries.add(library);
+    				}
 			}
+			map.put("libraries", newLibraries);
 			StringWriter writer = new StringWriter();
 			try {
 				Gsons.write(JsonWriter.json(writer), map);


### PR DESCRIPTION
The current method of replacing "org.quiltmc:hashed" with "net.fabricmc:intermediary" will result in duplicate entries for "net.fabricmc:intermediary" if the JSON already contains such an entry.
These libraries then get downloaded in parallel, resulting in an "AccessDeniedException" (tested on Windows Server 2019) because the two processes will attempt to write to the same file simultaneously:
```
Downloading library at: https://maven.fabricmc.net/net/fabricmc/intermediary/1.20.1/intermediary-1.20.1.jar
Downloading library at: https://maven.fabricmc.net/net/fabricmc/intermediary/1.20.1/intermediary-1.20.1.jar
java.util.concurrent.CompletionException: java.io.UncheckedIOException: java.nio.file.AccessDeniedException: .\libraries\net\fabricmc\intermediary\1.20.1\intermediary-1.20.1.jar
        at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(Unknown Source)
        at java.base/java.util.concurrent.CompletableFuture.completeThrowable(Unknown Source)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(Unknown Source)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.exec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
Caused by: java.io.UncheckedIOException: java.nio.file.AccessDeniedException: .\libraries\net\fabricmc\intermediary\1.20.1\intermediary-1.20.1.jar
        at org.quiltmc.installer.action.InstallServer.lambda$downloadLibrary$8(InstallServer.java:272)
        ... 7 more
Caused by: java.nio.file.AccessDeniedException: .\libraries\net\fabricmc\intermediary\1.20.1\intermediary-1.20.1.jar
        at java.base/sun.nio.fs.WindowsException.translateToIOException(Unknown Source)
        at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(Unknown Source)
        at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(Unknown Source)
        at java.base/sun.nio.fs.WindowsFileSystemProvider.newByteChannel(Unknown Source)
        at java.base/java.nio.file.spi.FileSystemProvider.newOutputStream(Unknown Source)
        at java.base/java.nio.file.Files.newOutputStream(Unknown Source)
        at java.base/java.nio.file.Files.copy(Unknown Source)
        at org.quiltmc.installer.action.InstallServer.lambda$downloadLibrary$8(InstallServer.java:267)
        ... 7 more
```

The suggested change removes duplicate entries from the library list, which solves the issue on my test system.